### PR TITLE
makefile: allow cross compiling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (C) 2020 Hong Shen <sh.iridium77@gmail.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ prefix = $(DESTDIR)/usr
 bindir = ${prefix}/bin
 mandir = ${prefix}/share/man
 
-CC = gcc
+CC ?= gcc
 CFLAGS += -Wall -O2
 #CFLAGS += -Wall -pedantic -ansi -O2
 

--- a/htpdate.c
+++ b/htpdate.c
@@ -1,8 +1,13 @@
 /*
 	htpdate v1.0.5
 
+	Original author:
 	Eddy Vervest <eddy@vervest.org>
 	http://www.vervest.org/htp
+
+	Actual maintainer:
+	Hong Shen <sh.iridium77@gmail.com>
+	https://github.com/iridium77
 
 	Synchronize local workstation with time offered by remote web servers
 
@@ -345,8 +350,8 @@ static int setclock( double timedelta, int setmode ) {
 		return(0);
 
 	case 1:						/* Adjust time smoothly */
-		timeofday.tv_sec  = (long)timedelta;	
-		timeofday.tv_usec = (long)((timedelta - timeofday.tv_sec) * 1000000);	
+		timeofday.tv_sec  = (long)timedelta;
+		timeofday.tv_usec = (long)((timedelta - timeofday.tv_sec) * 1000000);
 
 		printlog( 0, "Adjusting %.3f seconds", timedelta );
 
@@ -364,8 +369,8 @@ static int setclock( double timedelta, int setmode ) {
 		gettimeofday( &timeofday, NULL );
 		timedelta += ( timeofday.tv_sec + timeofday.tv_usec*1e-6 );
 
-		timeofday.tv_sec  = (long)timedelta;	
-		timeofday.tv_usec = (long)(timedelta - timeofday.tv_sec) * 1000000;	
+		timeofday.tv_sec  = (long)timedelta;
+		timeofday.tv_usec = (long)(timedelta - timeofday.tv_sec) * 1000000;
 
 		printlog( 0, "Set: %s", asctime(localtime(&timeofday.tv_sec)) );
 


### PR DESCRIPTION
In order to crosscompile, gcc executable cannot be hardcoded.

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>